### PR TITLE
Updates for binary encoding

### DIFF
--- a/cloudevents/sdk/converters/structured.py
+++ b/cloudevents/sdk/converters/structured.py
@@ -27,6 +27,12 @@ class JSONHTTPCloudEventConverter(base.Converter):
              headers: dict,
              body: typing.IO,
              data_unmarshaller: typing.Callable) -> event_base.BaseEvent:
+        # Note: this is fragile for true dictionaries which don't implement
+        # case-insensitive header mappings. HTTP/1.1 specifies that headers
+        #  are case insensitive, so this usually affects tests.
+        if not headers.get("Content-Type", "").startswith("application/cloudevents+json"):
+            raise exceptions.UnsupportedEvent(
+                "Structured mode must be application/cloudevents+json, not {0}".format(headers.get("content-type")))
         event.UnmarshalJSON(body, data_unmarshaller)
         return event
 

--- a/cloudevents/sdk/converters/structured.py
+++ b/cloudevents/sdk/converters/structured.py
@@ -32,10 +32,10 @@ class JSONHTTPCloudEventConverter(base.Converter):
         # Note: this is fragile for true dictionaries which don't implement
         # case-insensitive header mappings. HTTP/1.1 specifies that headers
         #  are case insensitive, so this usually affects tests.
-        if not headers.get("Content-Type", "").startswith(MIME_TYPE):
+        if not headers.get("Content-Type", "").startswith(self.MIME_TYPE):
             raise exceptions.UnsupportedEvent(
                 "Structured mode must be {0}, not {1}".format(
-                    MIME_TYPE, headers.get("content-type")))
+                    self.MIME_TYPE, headers.get("content-type")))
         event.UnmarshalJSON(body, data_unmarshaller)
         return event
 

--- a/cloudevents/sdk/converters/structured.py
+++ b/cloudevents/sdk/converters/structured.py
@@ -23,6 +23,8 @@ class JSONHTTPCloudEventConverter(base.Converter):
 
     TYPE = "structured"
 
+    MIME_TYPE = "application/cloudevents+json"
+
     def read(self, event: event_base.BaseEvent,
              headers: dict,
              body: typing.IO,
@@ -30,9 +32,10 @@ class JSONHTTPCloudEventConverter(base.Converter):
         # Note: this is fragile for true dictionaries which don't implement
         # case-insensitive header mappings. HTTP/1.1 specifies that headers
         #  are case insensitive, so this usually affects tests.
-        if not headers.get("Content-Type", "").startswith("application/cloudevents+json"):
+        if not headers.get("Content-Type", "").startswith(MIME_TYPE):
             raise exceptions.UnsupportedEvent(
-                "Structured mode must be application/cloudevents+json, not {0}".format(headers.get("content-type")))
+                "Structured mode must be {0}, not {1}".format(
+                    MIME_TYPE, headers.get("content-type")))
         event.UnmarshalJSON(body, data_unmarshaller)
         return event
 

--- a/cloudevents/sdk/event/base.py
+++ b/cloudevents/sdk/event/base.py
@@ -131,7 +131,8 @@ class BaseEvent(EventGetterSetter):
                         data_unmarshaller: typing.Callable):
         BINARY_MAPPING = {
             'content-type': 'contenttype',
-            # TODO: add Distributed Tracing. It's not clear if this is one extension or two.
+            # TODO(someone): add Distributed Tracing. It's not clear if this
+            # is one extension or two.
             # https://github.com/cloudevents/spec/blob/master/extensions/distributed-tracing.md
         }
         for header, value in headers.items():

--- a/cloudevents/sdk/marshaller.py
+++ b/cloudevents/sdk/marshaller.py
@@ -56,7 +56,12 @@ class HTTPMarshaller(object):
         :rtype: event_base.BaseEvent
         """
         for _, cnvrtr in self.__converters.items():
-            return cnvrtr.read(event, headers, body, data_unmarshaller)
+            try:
+                return cnvrtr.read(event, headers, body, data_unmarshaller)
+            except exceptions.UnsupportedEvent:
+                continue
+        raise exceptions.UnsupportedEvent(
+            "No registered marshaller in {0}".format(self.__converters))
 
     def ToRequest(self, event: event_base.BaseEvent,
                   converter_type: str,

--- a/cloudevents/tests/test_event_from_request_converter.py
+++ b/cloudevents/tests/test_event_from_request_converter.py
@@ -103,6 +103,7 @@ def test_default_http_marshaller_with_structured():
     assert event.Get("type") == (data.ce_type, True)
     assert event.Get("id") == (data.ce_id, True)
 
+
 def test_default_http_marshaller_with_binary():
     m = marshaller.NewDefaultHTTPMarshaller()
 

--- a/cloudevents/tests/test_event_from_request_converter.py
+++ b/cloudevents/tests/test_event_from_request_converter.py
@@ -90,7 +90,7 @@ def test_structured_converter_v01():
     assert event.Get("id") == (data.ce_id, True)
 
 
-def test_default_http_marshaller():
+def test_default_http_marshaller_with_structured():
     m = marshaller.NewDefaultHTTPMarshaller()
 
     event = m.FromRequest(
@@ -101,4 +101,18 @@ def test_default_http_marshaller():
     )
     assert event is not None
     assert event.Get("type") == (data.ce_type, True)
+    assert event.Get("id") == (data.ce_id, True)
+
+def test_default_http_marshaller_with_binary():
+    m = marshaller.NewDefaultHTTPMarshaller()
+
+    event = m.FromRequest(
+        v02.Event(),
+        data.headers,
+        io.StringIO(ujson.dumps(data.body)),
+        ujson.load
+    )
+    assert event is not None
+    assert event.Get("type") == (data.ce_type, True)
+    assert event.Get("data") == (data.body, True)
     assert event.Get("id") == (data.ce_id, True)

--- a/cloudevents/tests/test_event_pipeline.py
+++ b/cloudevents/tests/test_event_pipeline.py
@@ -42,7 +42,7 @@ def test_event_pipeline_upstream():
     assert "ce-source" in new_headers
     assert "ce-id" in new_headers
     assert "ce-time" in new_headers
-    assert "ce-contenttype" in new_headers
+    assert "content-type" in new_headers
     assert data.body == body
 
 


### PR DESCRIPTION
Updates binary encoding to handle [extensions](https://github.com/cloudevents/spec/blob/v0.2/http-transport-binding.md#3131-http-header-names) and [content-type](https://github.com/cloudevents/spec/blob/v0.2/http-transport-binding.md#311-http-content-type) per spec.

Update marshaller to handle both structured and binary formats. Previously, it would try structured first, even if the content-type did not match, and then ignore all the headers, producing very wimpy events with no data.

- Link to issue this resolves
I was too lazy to file an issue while debugging.

- What I did
I wrote a small python program using Flask to log cloud events, and to report them in a webpage. I'll be putting in in a pull request to https://github.com/knative/docs soon.

- How I did it
I used the following command to POST cloudevents to the flask program I wrote above.
```shell
curl -v -d '{}' \
  -H 'CE-SpecVersion: 0.2' \
  -H 'Content-Type: application/json; charset=utf-8' \
  -H 'CE-Source: "http://manual/"' \
  -H 'CE-Type: "local.badidea"' \
  -H 'CE-Id: 123' \
  -H 'CE-Time: "2019-01-11T23:40:00Z"' \
  -H 'CE-test: foo' \
  -H 'CE-test: bar' \
  -H 'CE-sampling: 2' \
  -H 'traceparent: aauau' \
  http://127.0.0.1:5000/
```

- How to verify it
I updated the tests.

- One line description for the changelog
```release-notes
* Updated library to better support binary encoding
```