### PR TITLE
Add content-type for long-description.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ name = cloudevents
 summary = CloudEvents SDK Python
 description-file =
     README.md
+long-description-content-type = text/markdown
 author = Denis Makogon
 author-email = denys.makogon@oracle.com
 home-page = https://cloudevents.io/


### PR DESCRIPTION
Causes markdown to render correctly on pypi.

- Link to issue this resolves
Too lazy to file an issue, AGAIN.

- What I did
Added long-description-content-type to `setup.cfg`

Might as well roll this in when you tag and distribute an 0.2.2 release.