### PR TITLE
WIP: Add some python pika examples

### DIFF
--- a/samples/python-pika/cloudevent_to_pika.py
+++ b/samples/python-pika/cloudevent_to_pika.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=C0111,C0103,R0205
+
+import logging
+import pika
+import json
+
+from cloudevents.sdk.event import v02
+
+print('pika version: %s' % pika.__version__)
+
+connection = pika.BlockingConnection(
+    pika.ConnectionParameters(
+        host='localhost',
+        credentials=pika.PlainCredentials('guest', 'guest')
+    )
+)
+
+main_channel = connection.channel()
+main_channel.exchange_declare(exchange='com.example.events', exchange_type='direct')
+
+event = (
+    v02.Event().
+    SetContentType("application/json").
+    SetData({"name": "denis"}).
+    SetEventID("my-id").
+    SetSource("<event-source").
+    SetEventType("cloudevent.event.type")
+)
+
+main_channel.basic_publish(
+    exchange='com.example.events',
+    routing_key=event.EventType(),
+    body=json.dumps(event.Data()),
+    properties=pika.BasicProperties(
+        content_type='application/json',
+        headers={
+            'cloudEvents:specversion': event.CloudEventVersion(),
+            'cloudEvents:type': event.EventType(),
+            'cloudEvents:id': event.EventID(),
+            'cloudEvents:source': event.Source()
+        }
+    )
+)
+connection.close()

--- a/samples/python-pika/pika_to_cloudevent.py
+++ b/samples/python-pika/pika_to_cloudevent.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=C0111,C0103,R0205
+
+import json
+import logging
+import pika
+
+print('pika version: %s' % pika.__version__)
+
+connection = pika.BlockingConnection(
+    pika.ConnectionParameters(
+        host='localhost',
+        credentials=pika.PlainCredentials('guest', 'guest')
+    )
+)
+
+main_channel = connection.channel()
+main_channel.exchange_declare(exchange='com.example.events', exchange_type='direct')
+queue = main_channel.queue_declare('', exclusive=True).method.queue
+main_channel.queue_bind(exchange='com.example.events', queue=queue, routing_key='cloudevent.event.type')
+
+def callback(_ch, _method, properties, body):
+    print(json.loads(body))
+    print(properties)
+
+main_channel.basic_consume(queue, callback, auto_ack=True)
+
+try:
+    main_channel.start_consuming()
+finally:
+    connection.close()


### PR DESCRIPTION
This adds a python pika example and how to marsall things in and
out. The consumer and producer are supposed to run in parallel,
the consumer is started first then the producer can be run any
number of times after that.

Even though this is a basic example of using pika with RabbitMQ,
there is still an open question about verifying the spec. Since
pika is wrapping both the input and output of the code, I have no
way to verify the data going in/out of the protocol matches the
cloud event spec.

Signed-off-by: David Brown <dmlb2000@gmail.com>

- Link to issue this resolves

Fix #18 

- What I did

- How I did it

- How to verify it

- One line description for the changelog

Add pika examples