### PR TITLE
Fix typo in extensions

### DIFF
--- a/cloudevents/sdk/event/v01.py
+++ b/cloudevents/sdk/event/v01.py
@@ -121,7 +121,7 @@ class Event(base.BaseEvent):
         return self
 
     def SetExtensions(self, extensions: dict) -> base.BaseEvent:
-        self.Set("extension", extensions)
+        self.Set("extensions", extensions)
         return self
 
     def SetContentType(self, contentType: str) -> base.BaseEvent:

--- a/cloudevents/sdk/event/v02.py
+++ b/cloudevents/sdk/event/v02.py
@@ -80,7 +80,7 @@ class Event(base.BaseEvent):
         return self
 
     def SetExtensions(self, extensions: dict) -> base.BaseEvent:
-        self.Set("extension", extensions)
+        self.Set("extensions", extensions)
         return self
 
     def SetContentType(self, contentType: str) -> base.BaseEvent:


### PR DESCRIPTION
- Link to issue this resolves

- What I did
Fixed a typo in the "extensions" setter

- How I did it
Added the missing "s"

- How to verify it

- One line description for the changelog
Fixed typo in the "extensions" setter