### PR TITLE
Specversion toggling

### DIFF
--- a/cloudevents/sdk/converters/__init__.py
+++ b/cloudevents/sdk/converters/__init__.py
@@ -12,7 +12,35 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import typing
+
 from cloudevents.sdk.converters import binary, structured
 
 TypeBinary = binary.BinaryHTTPCloudEventConverter.TYPE
 TypeStructured = structured.JSONHTTPCloudEventConverter.TYPE
+
+
+def is_binary(headers: typing.Dict[str, str]) -> bool:
+    """Uses internal marshallers to determine whether this event is binary
+    :param headers: the HTTP headers
+    :type headers: typing.Dict[str, str]
+    :returns bool: returns a bool indicating whether the headers indicate a binary event type
+    """
+    headers = {key.lower(): value for key, value in headers.items()}
+    content_type = headers.get("content-type", "")
+    binary_parser = binary.BinaryHTTPCloudEventConverter()
+    return binary_parser.can_read(content_type=content_type, headers=headers)
+
+
+def is_structured(headers: typing.Dict[str, str]) -> bool:
+    """Uses internal marshallers to determine whether this event is structured
+    :param headers: the HTTP headers
+    :type headers: typing.Dict[str, str]
+    :returns bool: returns a bool indicating whether the headers indicate a structured event type
+    """
+    headers = {key.lower(): value for key, value in headers.items()}
+    content_type = headers.get("content-type", "")
+    structured_parser = structured.JSONHTTPCloudEventConverter()
+    return structured_parser.can_read(
+        content_type=content_type, headers=headers
+    )

--- a/cloudevents/sdk/converters/binary.py
+++ b/cloudevents/sdk/converters/binary.py
@@ -16,6 +16,7 @@ import typing
 
 from cloudevents.sdk import exceptions, types
 from cloudevents.sdk.converters import base
+from cloudevents.sdk.converters.structured import JSONHTTPCloudEventConverter
 from cloudevents.sdk.event import base as event_base
 from cloudevents.sdk.event import v1, v03
 
@@ -30,7 +31,10 @@ class BinaryHTTPCloudEventConverter(base.Converter):
         content_type: str,
         headers: typing.Dict[str, str] = {"ce-specversion": None},
     ) -> bool:
-        return "ce-specversion" in headers
+        return ("ce-specversion" in headers) and not (
+            isinstance(content_type, str)
+            and content_type.startswith(JSONHTTPCloudEventConverter.MIME_TYPE)
+        )
 
     def event_supported(self, event: object) -> bool:
         return type(event) in self.SUPPORTED_VERSIONS

--- a/cloudevents/sdk/converters/binary.py
+++ b/cloudevents/sdk/converters/binary.py
@@ -25,8 +25,12 @@ class BinaryHTTPCloudEventConverter(base.Converter):
     TYPE = "binary"
     SUPPORTED_VERSIONS = [v03.Event, v1.Event]
 
-    def can_read(self, content_type: str) -> bool:
-        return True
+    def can_read(
+        self,
+        content_type: str,
+        headers: typing.Dict[str, str] = {"ce-specversion": None},
+    ) -> bool:
+        return "ce-specversion" in headers
 
     def event_supported(self, event: object) -> bool:
         return type(event) in self.SUPPORTED_VERSIONS

--- a/cloudevents/sdk/converters/structured.py
+++ b/cloudevents/sdk/converters/structured.py
@@ -24,8 +24,14 @@ class JSONHTTPCloudEventConverter(base.Converter):
     TYPE = "structured"
     MIME_TYPE = "application/cloudevents+json"
 
-    def can_read(self, content_type: str) -> bool:
-        return content_type and content_type.startswith(self.MIME_TYPE)
+    def can_read(
+        self,
+        content_type: str,
+        headers: typing.Dict[str, str] = {"ce-specversion": None},
+    ) -> bool:
+        return (content_type and content_type.startswith(self.MIME_TYPE)) or (
+            "ce-specversion" not in headers
+        )
 
     def event_supported(self, event: object) -> bool:
         # structured format supported by both spec 0.1 and 0.2

--- a/cloudevents/sdk/converters/structured.py
+++ b/cloudevents/sdk/converters/structured.py
@@ -29,9 +29,10 @@ class JSONHTTPCloudEventConverter(base.Converter):
         content_type: str,
         headers: typing.Dict[str, str] = {"ce-specversion": None},
     ) -> bool:
-        return (isinstance(content_type, str) and content_type.startswith(self.MIME_TYPE)) or (
-            "ce-specversion" not in headers
-        )
+        return (
+            isinstance(content_type, str)
+            and content_type.startswith(self.MIME_TYPE)
+        ) or ("ce-specversion" not in headers)
 
     def event_supported(self, event: object) -> bool:
         # structured format supported by both spec 0.1 and 0.2

--- a/cloudevents/sdk/converters/structured.py
+++ b/cloudevents/sdk/converters/structured.py
@@ -29,7 +29,7 @@ class JSONHTTPCloudEventConverter(base.Converter):
         content_type: str,
         headers: typing.Dict[str, str] = {"ce-specversion": None},
     ) -> bool:
-        return (content_type and content_type.startswith(self.MIME_TYPE)) or (
+        return (isinstance(content_type, str) and content_type.startswith(self.MIME_TYPE)) or (
             "ce-specversion" not in headers
         )
 

--- a/cloudevents/sdk/http_events.py
+++ b/cloudevents/sdk/http_events.py
@@ -80,13 +80,17 @@ class CloudEvent:
             # content-type = application/cloudevents+json.
             if converter.can_read(content_type, headers=headers):
                 if isinstance(converter, binary.BinaryHTTPCloudEventConverter):
+                    print("WHAT HAPPENED")
                     specversion = headers.get("ce-specversion", None)
                     break
                 elif isinstance(
                     converter, structured.JSONHTTPCloudEventConverter
                 ):
                     raw_ce = json.loads(data)
+                    
+
                     specversion = raw_ce.get("specversion", None)
+                    print('REACHED', raw_ce, specversion)
                     # Breaking because while structured may or may not return
                     # true on can_read, binary will always return true. Without
                     # a break specversion for structured events will always be

--- a/cloudevents/sdk/http_events.py
+++ b/cloudevents/sdk/http_events.py
@@ -18,7 +18,7 @@ import typing
 import uuid
 
 from cloudevents.sdk import converters, marshaller, types
-from cloudevents.sdk.converters import binary, structured
+from cloudevents.sdk.converters import is_binary
 from cloudevents.sdk.event import v1, v03
 from cloudevents.sdk.marshaller import HTTPMarshaller
 
@@ -42,20 +42,6 @@ def _json_or_string(content: typing.Union[str, bytes]):
         return content
 
 
-def is_binary(
-    headers: typing.Dict[str, str]
-) -> bool:
-    """Uses internal marshallers to determine whether this event is binary
-    :param headers: the HTTP headers
-    :type headers: typing.Dict[str, str]
-    :returns bool: returns a bool indicating whether the headers indicate a binary event type
-    """
-    headers = {key.lower(): value for key, value in headers.items()}
-    content_type = headers.get("content-type", "")
-    binary_parser = binary.BinaryHTTPCloudEventConverter()
-    return binary_parser.can_read(content_type=content_type, headers=headers)
-
-    
 class CloudEvent:
     """
     Python-friendly cloudevent class supporting v1 events

--- a/cloudevents/sdk/http_events.py
+++ b/cloudevents/sdk/http_events.py
@@ -82,8 +82,9 @@ class CloudEvent:
                 else:
                     raise NotImplementedError
 
-        event_handlr = _obj_by_version[specversion]
-        event = marshaller.NewDefaultHTTPMarshaller().FromRequest(
+        # Should this throw if given invalid event?
+        event_handlr = _obj_by_version.get(specversion, "1.0")
+        event = marshall.FromRequest(
             event_handlr(), headers, data, data_unmarshaller
         )
         attrs = event.Properties()

--- a/cloudevents/sdk/http_events.py
+++ b/cloudevents/sdk/http_events.py
@@ -86,7 +86,6 @@ class CloudEvent:
                     converter, structured.JSONHTTPCloudEventConverter
                 ):
                     raw_ce = json.loads(data)
-                    print("README: ", raw_ce)
                     specversion = raw_ce.get("specversion", None)
                     # Breaking because while structured may or may not return
                     # true on can_read, binary will always return true. Without

--- a/cloudevents/sdk/http_events.py
+++ b/cloudevents/sdk/http_events.py
@@ -80,17 +80,14 @@ class CloudEvent:
             # content-type = application/cloudevents+json.
             if converter.can_read(content_type, headers=headers):
                 if isinstance(converter, binary.BinaryHTTPCloudEventConverter):
-                    print("WHAT HAPPENED")
                     specversion = headers.get("ce-specversion", None)
                     break
                 elif isinstance(
                     converter, structured.JSONHTTPCloudEventConverter
                 ):
                     raw_ce = json.loads(data)
-                    
 
                     specversion = raw_ce.get("specversion", None)
-                    print('REACHED', raw_ce, specversion)
                     # Breaking because while structured may or may not return
                     # true on can_read, binary will always return true. Without
                     # a break specversion for structured events will always be

--- a/cloudevents/sdk/http_events.py
+++ b/cloudevents/sdk/http_events.py
@@ -78,7 +78,7 @@ class CloudEvent:
             # structured converter is the first converter we iterate through.
             # structured returns true if and only if
             # content-type = application/cloudevents+json.
-            if converter.can_read(content_type):
+            if converter.can_read(content_type, headers=headers):
                 if isinstance(converter, binary.BinaryHTTPCloudEventConverter):
                     specversion = headers.get("ce-specversion", None)
                     break
@@ -86,6 +86,7 @@ class CloudEvent:
                     converter, structured.JSONHTTPCloudEventConverter
                 ):
                     raw_ce = json.loads(data)
+                    print("README: ", raw_ce)
                     specversion = raw_ce.get("specversion", None)
                     # Breaking because while structured may or may not return
                     # true on can_read, binary will always return true. Without

--- a/cloudevents/sdk/marshaller.py
+++ b/cloudevents/sdk/marshaller.py
@@ -63,7 +63,7 @@ class HTTPMarshaller(object):
         content_type = headers.get("content-type", None)
 
         for cnvrtr in self.http_converters:
-            if cnvrtr.can_read(content_type) and cnvrtr.event_supported(event):
+            if cnvrtr.can_read(content_type, headers=headers) and cnvrtr.event_supported(event):
                 return cnvrtr.read(event, headers, body, data_unmarshaller)
 
         raise exceptions.UnsupportedEventConverter(

--- a/cloudevents/sdk/marshaller.py
+++ b/cloudevents/sdk/marshaller.py
@@ -63,7 +63,9 @@ class HTTPMarshaller(object):
         content_type = headers.get("content-type", None)
 
         for cnvrtr in self.http_converters:
-            if cnvrtr.can_read(content_type, headers=headers) and cnvrtr.event_supported(event):
+            if cnvrtr.can_read(
+                content_type, headers=headers
+            ) and cnvrtr.event_supported(event):
                 return cnvrtr.read(event, headers, body, data_unmarshaller)
 
         raise exceptions.UnsupportedEventConverter(

--- a/cloudevents/sdk/marshaller.py
+++ b/cloudevents/sdk/marshaller.py
@@ -32,8 +32,8 @@ class HTTPMarshaller(object):
         :param converters: a list of HTTP-to-CloudEvent-to-HTTP constructors
         :type converters: typing.List[base.Converter]
         """
-        self.__converters = [c for c in converters]
-        self.__converters_by_type = {c.TYPE: c for c in converters}
+        self.http_converters = [c for c in converters]
+        self.http_converters_by_type = {c.TYPE: c for c in converters}
 
     def FromRequest(
         self,
@@ -62,13 +62,13 @@ class HTTPMarshaller(object):
         headers = {key.lower(): value for key, value in headers.items()}
         content_type = headers.get("content-type", None)
 
-        for cnvrtr in self.__converters:
+        for cnvrtr in self.http_converters:
             if cnvrtr.can_read(content_type) and cnvrtr.event_supported(event):
                 return cnvrtr.read(event, headers, body, data_unmarshaller)
 
         raise exceptions.UnsupportedEventConverter(
             "No registered marshaller for {0} in {1}".format(
-                content_type, self.__converters
+                content_type, self.http_converters
             )
         )
 
@@ -95,10 +95,10 @@ class HTTPMarshaller(object):
             raise exceptions.InvalidDataMarshaller()
 
         if converter_type is None:
-            converter_type = self.__converters[0].TYPE
+            converter_type = self.http_converters[0].TYPE
 
-        if converter_type in self.__converters_by_type:
-            cnvrtr = self.__converters_by_type[converter_type]
+        if converter_type in self.http_converters_by_type:
+            cnvrtr = self.http_converters_by_type[converter_type]
             return cnvrtr.write(event, data_marshaller)
 
         raise exceptions.NoSuchConverter(converter_type)

--- a/cloudevents/tests/test_http_events.py
+++ b/cloudevents/tests/test_http_events.py
@@ -196,7 +196,9 @@ def test_missing_ce_prefix_binary_event(specversion):
             # and NotImplementedError because structured calls aren't
             # implemented. In this instance one of the required keys should have
             # prefix e-id instead of ce-id therefore it should throw
-            _ = CloudEvent.from_http(test_data, headers=prefixed_headers)
+            _ = CloudEvent.from_http(
+                json.dumps(test_data), headers=prefixed_headers
+            )
 
 
 @pytest.mark.parametrize("specversion", ["1.0", "0.3"])

--- a/cloudevents/tests/test_http_events.py
+++ b/cloudevents/tests/test_http_events.py
@@ -324,3 +324,28 @@ def test_valid_structured_events(specversion):
         assert event["source"] == f"source{i}.com.test"
         assert event["specversion"] == specversion
         assert event.data["payload"] == f"payload-{i}"
+
+
+@pytest.mark.parametrize("specversion", ["1.0", "0.3"])
+def test_structured_no_content_type(specversion):
+    # Test creating multiple cloud events
+    events_queue = []
+    headers = {}
+    num_cloudevents = 30
+    data = {
+        "id": "id",
+        "source": "source.com.test",
+        "type": "cloudevent.test.type",
+        "specversion": specversion,
+        "data": test_data,
+    }
+    event = CloudEvent.from_http(
+        json.dumps(data),
+        {},
+    )
+
+    assert event["id"] == "id"
+    assert event["source"] == "source.com.test"
+    assert event["specversion"] == specversion
+    for key, val in test_data.items():
+        assert event.data[key] == val

--- a/cloudevents/tests/test_http_events.py
+++ b/cloudevents/tests/test_http_events.py
@@ -339,10 +339,7 @@ def test_structured_no_content_type(specversion):
         "specversion": specversion,
         "data": test_data,
     }
-    event = CloudEvent.from_http(
-        json.dumps(data),
-        {},
-    )
+    event = CloudEvent.from_http(json.dumps(data), {},)
 
     assert event["id"] == "id"
     assert event["source"] == "source.com.test"

--- a/cloudevents/tests/test_http_events.py
+++ b/cloudevents/tests/test_http_events.py
@@ -346,3 +346,35 @@ def test_structured_no_content_type(specversion):
     assert event["specversion"] == specversion
     for key, val in test_data.items():
         assert event.data[key] == val
+
+
+def test_is_binary():
+    headers = {
+        "ce-id": "my-id",
+        "ce-source": "<event-source>",
+        "ce-type": "cloudevent.event.type",
+        "ce-specversion": "1.0",
+        "Content-Type": "text/plain",
+    }
+    assert converters.is_binary(headers)
+
+    headers = {
+        "Content-Type": "application/cloudevents+json",
+    }
+    assert not converters.is_binary(headers)
+
+    headers = {}
+    assert not converters.is_binary(headers)
+
+
+def test_is_structured():
+    headers = {
+        "Content-Type": "application/cloudevents+json",
+    }
+    assert converters.is_structured(headers)
+
+    headers = {}
+    assert converters.is_structured(headers)
+
+    headers = {"ce-specversion": "1.0"}
+    assert not converters.is_structured(headers)


### PR DESCRIPTION
Fixes #54

## Changes
from_http now marshalls with correct base event class depending on specversion. Created a converter is_binary function to givee from_http a hint as to whether given http headers is binary or not.

## One line description for the changelog
from_http now marshalls with correct base event class depending on specversion

- [*] Tests pass
- [*] Appropriate changes to README are included in PR
