### PR TITLE
Fixed top level extensions bug

### DIFF
--- a/cloudevents/sdk/event/base.py
+++ b/cloudevents/sdk/event/base.py
@@ -201,6 +201,9 @@ class BaseEvent(EventGetterSetter):
                 props["data_base64"] = base64.b64encode(data).decode("ascii")
             else:
                 props["data"] = data
+        if "extensions" in props:
+            extensions = props.pop("extensions")
+            props.update(extensions)
         return json.dumps(props)
 
     def UnmarshalJSON(

--- a/cloudevents/tests/test_event_extensions.py
+++ b/cloudevents/tests/test_event_extensions.py
@@ -99,4 +99,3 @@ def test_from_structured_extensions(specversion):
 
     assert body["ext1"] == event["ext1"]
     assert body["ext2"] == event["ext2"]
-

--- a/cloudevents/tests/test_event_extensions.py
+++ b/cloudevents/tests/test_event_extensions.py
@@ -22,32 +22,27 @@ from cloudevents.sdk.http import (
     to_structured_http,
 )
 
+test_data = json.dumps({"data-key": "val"})
+test_attributes = {
+    "type": "com.example.string",
+    "source": "https://example.com/event-producer",
+    "ext1": "testval",
+}
+
 
 @pytest.mark.parametrize("specversion", ["0.3", "1.0"])
 def test_cloudevent_access_extensions(specversion):
-    attributes = {
-        "type": "com.example.string",
-        "source": "https://example.com/event-producer",
-        "ext1": "testval",
-    }
-    data = {"data-key": "val"}
-    event = CloudEvent(attributes, data)
+    event = CloudEvent(test_attributes, test_data)
     assert event["ext1"] == "testval"
 
 
 @pytest.mark.parametrize("specversion", ["0.3", "1.0"])
 def test_to_binary_extensions(specversion):
-    attributes = {
-        "type": "com.example.string",
-        "source": "https://example.com/event-producer",
-        "ext1": "testval",
-    }
-    data = json.dumps({"data-key": "val"})
-    event = CloudEvent(attributes, data)
-
+    event = CloudEvent(test_attributes, test_data)
     headers, body = to_binary_http(event)
+
     assert "ce-ext1" in headers
-    assert headers.get("ce-ext1") == attributes["ext1"]
+    assert headers.get("ce-ext1") == test_attributes["ext1"]
 
 
 @pytest.mark.parametrize("specversion", ["0.3", "1.0"])
@@ -69,16 +64,11 @@ def test_from_binary_extensions(specversion):
 
 @pytest.mark.parametrize("specversion", ["0.3", "1.0"])
 def test_to_structured_extensions(specversion):
-    attributes = {
-        "type": "com.example.string",
-        "source": "https://example.com/event-producer",
-        "ext1": "testval",
-    }
-    data = json.dumps({"data-key": "val"})
-    event = CloudEvent(attributes, data)
-
+    event = CloudEvent(test_attributes, test_data)
     headers, body = to_structured_http(event)
+
     body = json.loads(body)
+
     assert "ext1" in body
     assert "extensions" not in body
 
@@ -94,6 +84,7 @@ def test_from_structured_extensions(specversion):
         "ext1": "test1",
         "ext2": "test2",
     }
+
     data = json.dumps(body)
     event = from_http(data, headers)
 

--- a/cloudevents/tests/test_event_extensions.py
+++ b/cloudevents/tests/test_event_extensions.py
@@ -1,0 +1,102 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import json
+
+import pytest
+
+from cloudevents.sdk.http import (
+    CloudEvent,
+    from_http,
+    to_binary_http,
+    to_structured_http,
+)
+
+
+@pytest.mark.parametrize("specversion", ["0.3", "1.0"])
+def test_cloudevent_access_extensions(specversion):
+    attributes = {
+        "type": "com.example.string",
+        "source": "https://example.com/event-producer",
+        "ext1": "testval",
+    }
+    data = {"data-key": "val"}
+    event = CloudEvent(attributes, data)
+    assert event["ext1"] == "testval"
+
+
+@pytest.mark.parametrize("specversion", ["0.3", "1.0"])
+def test_to_binary_extensions(specversion):
+    attributes = {
+        "type": "com.example.string",
+        "source": "https://example.com/event-producer",
+        "ext1": "testval",
+    }
+    data = json.dumps({"data-key": "val"})
+    event = CloudEvent(attributes, data)
+
+    headers, body = to_binary_http(event)
+    assert "ce-ext1" in headers
+    assert headers.get("ce-ext1") == attributes["ext1"]
+
+
+@pytest.mark.parametrize("specversion", ["0.3", "1.0"])
+def test_from_binary_extensions(specversion):
+    headers = {
+        "ce-id": "1234",
+        "ce-source": "<my url>",
+        "ce-type": "sample",
+        "ce-specversion": specversion,
+        "ce-ext1": "test1",
+        "ce-ext2": "test2",
+    }
+    body = json.dumps({"data-key": "val"})
+    event = from_http(body, headers)
+
+    assert headers["ce-ext1"] == event["ext1"]
+    assert headers["ce-ext2"] == event["ext2"]
+
+
+@pytest.mark.parametrize("specversion", ["0.3", "1.0"])
+def test_to_structured_extensions(specversion):
+    attributes = {
+        "type": "com.example.string",
+        "source": "https://example.com/event-producer",
+        "ext1": "testval",
+    }
+    data = json.dumps({"data-key": "val"})
+    event = CloudEvent(attributes, data)
+
+    headers, body = to_structured_http(event)
+    body = json.loads(body)
+    assert "ext1" in body
+    assert "extensions" not in body
+
+
+@pytest.mark.parametrize("specversion", ["0.3", "1.0"])
+def test_from_structured_extensions(specversion):
+    headers = {"Content-Type": "application/cloudevents+json"}
+    body = {
+        "id": "1234",
+        "source": "<my url>",
+        "type": "sample",
+        "specversion": specversion,
+        "ext1": "test1",
+        "ext2": "test2",
+    }
+    data = json.dumps(body)
+    event = from_http(data, headers)
+
+    assert body["ext1"] == event["ext1"]
+    assert body["ext2"] == event["ext2"]
+

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,3 +9,5 @@ pytest-cov==2.4.0
 sanic
 aiohttp
 Pillow
+requests
+


### PR DESCRIPTION
Fixes #64, #62, #32

## Changes
```python
import json
from cloudevents.sdk.http import CloudEvent, to_structured_http

attributes = {
    "type": "com.example.string",
    "source": "https://example.com/event-producer",
    "ext1": "testval"
}
data = json.dumps({"data-key": "val"})
event = CloudEvent(attributes, data)

headers, body = to_structured_http(event)
print(body)
```

Will now print 

```
b'{"specversion": "1.0", "id": "45572bc9-4b9c-4230-9766-e4a5b180211d", "source": "https://example.com/event-producer", "type": "com.example.string", "time": "2020-07-22T07:23:17.117072+00:00", "data": "{\\"data-key\\": \\"val\\"}", "ext1": "testval"}'
```

Whereas before this change it would print non-top level extensions such as:

```
b'{"specversion": "1.0", "id": "be8e6b26-5a0a-47b7-8118-d9a6d84c181c", "source": "https://example.com/event-producer", "type": "com.example.string", "time": "2020-07-22T07:24:51.598809+00:00", "extensions": {"ext1": "testval"}, "data": "{\\"data-key\\": \\"val\\"}"}'
```

As you can see in the above, the attribute "extensions" should not be present in the marshalled json if I understand correctly. Furthermore, empty extensions dict's will no longer be marshalled as well. 

## One line description for the changelog
Top level extensions fix

- [*] Tests pass
- [*] Appropriate changes to README are included in PR
