### PR TITLE
cloudevent fields type checking adjustments

### DIFF
--- a/cloudevents/exceptions.py
+++ b/cloudevents/exceptions.py
@@ -1,0 +1,19 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+class CloudEventMissingRequiredFields(Exception):
+    pass
+
+
+class CloudEventTypeErrorRequiredFields(Exception):
+    pass

--- a/cloudevents/http/__init__.py
+++ b/cloudevents/http/__init__.py
@@ -15,6 +15,7 @@ import json
 import typing
 
 from cloudevents.http.event import CloudEvent
+from cloudevents.http.event_type import is_binary, is_structured
 from cloudevents.http.http_methods import (
     from_http,
     to_binary_http,

--- a/cloudevents/http/event.py
+++ b/cloudevents/http/event.py
@@ -16,6 +16,7 @@ import datetime
 import typing
 import uuid
 
+import cloudevents.exceptions as cloud_exceptions
 from cloudevents.http.mappings import _required_by_version
 
 
@@ -57,14 +58,14 @@ class CloudEvent:
             ).isoformat()
 
         if self._attributes["specversion"] not in _required_by_version:
-            raise ValueError(
+            raise cloud_exceptions.CloudEventMissingRequiredFields(
                 f"Invalid specversion: {self._attributes['specversion']}"
             )
         # There is no good way to default 'source' and 'type', so this
         # checks for those (or any new required attributes).
         required_set = _required_by_version[self._attributes["specversion"]]
         if not required_set <= self._attributes.keys():
-            raise ValueError(
+            raise cloud_exceptions.CloudEventMissingRequiredFields(
                 f"Missing required keys: {required_set - attributes.keys()}"
             )
 

--- a/cloudevents/http/event_type.py
+++ b/cloudevents/http/event_type.py
@@ -1,0 +1,29 @@
+import typing
+
+from cloudevents.sdk.converters import binary, structured
+
+
+def is_binary(headers: typing.Dict[str, str]) -> bool:
+    """Uses internal marshallers to determine whether this event is binary
+    :param headers: the HTTP headers
+    :type headers: typing.Dict[str, str]
+    :returns bool: returns a bool indicating whether the headers indicate a binary event type
+    """
+    headers = {key.lower(): value for key, value in headers.items()}
+    content_type = headers.get("content-type", "")
+    binary_parser = binary.BinaryHTTPCloudEventConverter()
+    return binary_parser.can_read(content_type=content_type, headers=headers)
+
+
+def is_structured(headers: typing.Dict[str, str]) -> bool:
+    """Uses internal marshallers to determine whether this event is structured
+    :param headers: the HTTP headers
+    :type headers: typing.Dict[str, str]
+    :returns bool: returns a bool indicating whether the headers indicate a structured event type
+    """
+    headers = {key.lower(): value for key, value in headers.items()}
+    content_type = headers.get("content-type", "")
+    structured_parser = structured.JSONHTTPCloudEventConverter()
+    return structured_parser.can_read(
+        content_type=content_type, headers=headers
+    )

--- a/cloudevents/http/http_methods.py
+++ b/cloudevents/http/http_methods.py
@@ -1,6 +1,7 @@
 import json
 import typing
 
+import cloudevents.exceptions as cloud_exceptions
 from cloudevents.http.event import CloudEvent
 from cloudevents.http.mappings import _marshaller_by_format, _obj_by_version
 from cloudevents.http.util import _json_or_string
@@ -34,12 +35,16 @@ def from_http(
         specversion = raw_ce.get("specversion", None)
 
     if specversion is None:
-        raise ValueError("could not find specversion in HTTP request")
+        raise cloud_exceptions.CloudEventMissingRequiredFields(
+            "could not find specversion in HTTP request"
+        )
 
     event_handler = _obj_by_version.get(specversion, None)
 
     if event_handler is None:
-        raise ValueError(f"found invalid specversion {specversion}")
+        raise cloud_exceptions.CloudEventTypeErrorRequiredFields(
+            f"found invalid specversion {specversion}"
+        )
 
     event = marshall.FromRequest(
         event_handler(), headers, data, data_unmarshaller=data_unmarshaller
@@ -71,7 +76,7 @@ def _to_http(
         data_marshaller = _marshaller_by_format[format]
 
     if event._attributes["specversion"] not in _obj_by_version:
-        raise ValueError(
+        raise cloud_exceptions.CloudEventTypeErrorRequiredFields(
             f"Unsupported specversion: {event._attributes['specversion']}"
         )
 

--- a/cloudevents/http/http_methods.py
+++ b/cloudevents/http/http_methods.py
@@ -3,6 +3,7 @@ import typing
 
 import cloudevents.exceptions as cloud_exceptions
 from cloudevents.http.event import CloudEvent
+from cloudevents.http.event_type import is_binary, is_structured
 from cloudevents.http.mappings import _marshaller_by_format, _obj_by_version
 from cloudevents.http.util import _json_or_string
 from cloudevents.sdk import converters, marshaller, types
@@ -28,7 +29,7 @@ def from_http(
 
     marshall = marshaller.NewDefaultHTTPMarshaller()
 
-    if converters.is_binary(headers):
+    if is_binary(headers):
         specversion = headers.get("ce-specversion", None)
     else:
         raw_ce = json.loads(data)

--- a/cloudevents/sdk/converters/__init__.py
+++ b/cloudevents/sdk/converters/__init__.py
@@ -11,36 +11,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
-import typing
-
 from cloudevents.sdk.converters import binary, structured
 
 TypeBinary = binary.BinaryHTTPCloudEventConverter.TYPE
 TypeStructured = structured.JSONHTTPCloudEventConverter.TYPE
-
-
-def is_binary(headers: typing.Dict[str, str]) -> bool:
-    """Uses internal marshallers to determine whether this event is binary
-    :param headers: the HTTP headers
-    :type headers: typing.Dict[str, str]
-    :returns bool: returns a bool indicating whether the headers indicate a binary event type
-    """
-    headers = {key.lower(): value for key, value in headers.items()}
-    content_type = headers.get("content-type", "")
-    binary_parser = binary.BinaryHTTPCloudEventConverter()
-    return binary_parser.can_read(content_type=content_type, headers=headers)
-
-
-def is_structured(headers: typing.Dict[str, str]) -> bool:
-    """Uses internal marshallers to determine whether this event is structured
-    :param headers: the HTTP headers
-    :type headers: typing.Dict[str, str]
-    :returns bool: returns a bool indicating whether the headers indicate a structured event type
-    """
-    headers = {key.lower(): value for key, value in headers.items()}
-    content_type = headers.get("content-type", "")
-    structured_parser = structured.JSONHTTPCloudEventConverter()
-    return structured_parser.can_read(
-        content_type=content_type, headers=headers
-    )

--- a/cloudevents/sdk/converters/binary.py
+++ b/cloudevents/sdk/converters/binary.py
@@ -16,7 +16,7 @@ import typing
 
 from cloudevents.sdk import exceptions, types
 from cloudevents.sdk.converters import base
-from cloudevents.sdk.converters.structured import JSONHTTPCloudEventConverter
+from cloudevents.sdk.converters.util import has_binary_headers
 from cloudevents.sdk.event import base as event_base
 from cloudevents.sdk.event import v1, v03
 
@@ -28,13 +28,11 @@ class BinaryHTTPCloudEventConverter(base.Converter):
 
     def can_read(
         self,
-        content_type: str,
+        content_type: str = None,
         headers: typing.Dict[str, str] = {"ce-specversion": None},
     ) -> bool:
-        return ("ce-specversion" in headers) and not (
-            isinstance(content_type, str)
-            and content_type.startswith(JSONHTTPCloudEventConverter.MIME_TYPE)
-        )
+
+        return has_binary_headers(headers)
 
     def event_supported(self, event: object) -> bool:
         return type(event) in self.SUPPORTED_VERSIONS

--- a/cloudevents/sdk/converters/structured.py
+++ b/cloudevents/sdk/converters/structured.py
@@ -16,23 +16,25 @@ import typing
 
 from cloudevents.sdk import types
 from cloudevents.sdk.converters import base
+from cloudevents.sdk.converters.binary import BinaryHTTPCloudEventConverter
+from cloudevents.sdk.converters.util import has_binary_headers
 from cloudevents.sdk.event import base as event_base
 
 
+# TODO: Singleton?
 class JSONHTTPCloudEventConverter(base.Converter):
 
     TYPE = "structured"
     MIME_TYPE = "application/cloudevents+json"
 
     def can_read(
-        self,
-        content_type: str,
-        headers: typing.Dict[str, str] = {"ce-specversion": None},
+        self, content_type: str, headers: typing.Dict[str, str] = {},
     ) -> bool:
         return (
             isinstance(content_type, str)
             and content_type.startswith(self.MIME_TYPE)
-        ) or ("ce-specversion" not in headers)
+            or not has_binary_headers(headers)
+        )
 
     def event_supported(self, event: object) -> bool:
         # structured format supported by both spec 0.1 and 0.2

--- a/cloudevents/sdk/converters/util.py
+++ b/cloudevents/sdk/converters/util.py
@@ -1,0 +1,10 @@
+import typing
+
+
+def has_binary_headers(headers: typing.Dict[str, str]) -> bool:
+    return (
+        "ce-specversion" in headers
+        and "ce-source" in headers
+        and "ce-type" in headers
+        and "ce-id" in headers
+    )

--- a/cloudevents/tests/test_http_events.py
+++ b/cloudevents/tests/test_http_events.py
@@ -24,6 +24,7 @@ import cloudevents.exceptions as cloud_exceptions
 from cloudevents.http import (
     CloudEvent,
     from_http,
+    is_binary,
     to_binary_http,
     to_structured_http,
 )
@@ -364,15 +365,15 @@ def test_is_binary():
         "ce-specversion": "1.0",
         "Content-Type": "text/plain",
     }
-    assert converters.is_binary(headers)
+    assert is_binary(headers)
 
     headers = {
         "Content-Type": "application/cloudevents+json",
     }
-    assert not converters.is_binary(headers)
+    assert not is_binary(headers)
 
     headers = {}
-    assert not converters.is_binary(headers)
+    assert not is_binary(headers)
 
 
 @pytest.mark.parametrize("specversion", ["1.0", "0.3"])


### PR DESCRIPTION
Fixes #95, #94, #92 

## Changes
#92:
moved 
```python
from cloudevents.sdk.converters import is_binary, is_structured
```

into 
```python
from cloudevents.http import is_binary, is_structured
```

#94 
added
```python
from cloudevents.exceptions import CloudEventMissingRequiredFields, CloudEventTypeErrorRequiredFields
```

#95:
[BinaryHTTPCloudEventConverter.can_read](https://github.com/cloudevents/sdk-python/blob/is_binary_can_read_fix/cloudevents/sdk/converters/binary.py)
now checks 4 required fields instead of just 1

## One line description for the changelog
cloudevent fields type checking adjustments

- [*] Tests pass
- [*] Appropriate changes to README are included in PR
