### PR TITLE
ignore datacontenttype when using to_binary()

### DIFF
--- a/cloudevents/sdk/event/base.py
+++ b/cloudevents/sdk/event/base.py
@@ -292,7 +292,7 @@ class BaseEvent(EventGetterSetter):
             headers["content-type"] = self.ContentType()
         props = self.Properties()
         for key, value in props.items():
-            if key not in ["data", "extensions", "contenttype"]:
+            if key not in ["data", "extensions", "datacontenttype"]:
                 if value is not None:
                     headers["ce-{0}".format(key)] = value
 

--- a/cloudevents/tests/test_with_sanic.py
+++ b/cloudevents/tests/test_with_sanic.py
@@ -34,7 +34,7 @@ async def echo(request):
         v1.Event(), dict(request.headers), request.body, lambda x: x
     )
     hs, body = m.ToRequest(event, converters.TypeBinary, lambda x: x)
-    return response.text(body, headers=hs)
+    return response.text(body.decode("utf-8"), headers=hs)
 
 
 def test_reusable_marshaller():

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,8 +6,7 @@ flake8-strict
 pytest==4.0.0
 pytest-cov==2.4.0
 # web app tests
-sanic
-sanic_testing
+sanic==20.12.3
 aiohttp
 Pillow
 requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,6 +7,7 @@ pytest==4.0.0
 pytest-cov==2.4.0
 # web app tests
 sanic
+sanic_testing
 aiohttp
 Pillow
 requests


### PR DESCRIPTION
Fixes https://github.com/cloudevents/sdk-python/issues/137

## Changes


## One line description for the changelog


- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
