### PR TITLE
Remove WIP notice from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,10 @@
 
 ## Status
 
-This SDK is still considered a work in progress, therefore things might (and
-will) break with every update.
+This SDK currently supports the following versions of CloudEvents:
 
-This SDK current supports the following versions of CloudEvents:
-
-- v1.0
-- v0.3
+- [v1.0](https://github.com/cloudevents/spec/blob/v1.0.1/spec.md)
+- [v0.3](https://github.com/cloudevents/spec/blob/v0.3/spec.md)
 
 ## Python SDK
 


### PR DESCRIPTION
Version 1.0.0 has already been tagged. Assuming the project is following semantic versioning, breaking changes require a new major release. This package doesn't seem to be racing through major releases, and seems to have implemented the majority of the spec, so this status information is no longer correct.