### PR TITLE
fix incorrect error messages for from_http()

### DIFF
--- a/cloudevents/sdk/converters/util.py
+++ b/cloudevents/sdk/converters/util.py
@@ -4,7 +4,7 @@ import typing
 def has_binary_headers(headers: typing.Dict[str, str]) -> bool:
     return (
         "ce-specversion" in headers
-        and "ce-source" in headers
-        and "ce-type" in headers
-        and "ce-id" in headers
+        or "ce-source" in headers
+        or "ce-type" in headers
+        or "ce-id" in headers
     )


### PR DESCRIPTION
Fixes https://github.com/cloudevents/sdk-python/issues/139

Align the logic of `has_binary_headers()` with [sdk-go](https://github.com/cloudevents/sdk-go/blob/70febdc855835091a1d5f111d9223f226eb0ab0a/v2/protocol/http/message.go#L58-L99)

Using `ce-specversion` is enough.


```go
func NewMessage(header nethttp.Header, body io.ReadCloser) *Message {
	m := Message{Header: header}
	if body != nil {
		m.BodyReader = body
	}
	if m.format = format.Lookup(header.Get(ContentType)); m.format == nil {
		m.version = specs.Version(m.Header.Get(specs.PrefixedSpecVersionName()))
	}
	return &m
}

func (m *Message) ReadEncoding() binding.Encoding {
	if m.version != nil {
		return binding.EncodingBinary
	}
	if m.format != nil {
		return binding.EncodingStructured
	}
	return binding.EncodingUnknown
}
```



## Changes


## One line description for the changelog


- [x] Tests pass
- [x] Appropriate changes to README are included in PR
