### PR TITLE
ci: use valid sanic instance name

### DIFF
--- a/cloudevents/tests/test_http_events.py
+++ b/cloudevents/tests/test_http_events.py
@@ -66,7 +66,7 @@ invalid_cloudevent_request_body = [
 
 test_data = {"payload-content": "Hello World!"}
 
-app = Sanic(__name__)
+app = Sanic()
 
 
 @app.route("/event", ["POST"])

--- a/cloudevents/tests/test_http_events.py
+++ b/cloudevents/tests/test_http_events.py
@@ -66,7 +66,7 @@ invalid_cloudevent_request_body = [
 
 test_data = {"payload-content": "Hello World!"}
 
-app = Sanic()
+app = Sanic("test_http_events")
 
 
 @app.route("/event", ["POST"])

--- a/cloudevents/tests/test_with_sanic.py
+++ b/cloudevents/tests/test_with_sanic.py
@@ -19,7 +19,7 @@ from cloudevents.sdk.event import v1
 from cloudevents.tests import data as test_data
 
 m = marshaller.NewDefaultHTTPMarshaller()
-app = Sanic(__name__)
+app = Sanic()
 
 
 @app.route("/is-ok", ["POST"])

--- a/cloudevents/tests/test_with_sanic.py
+++ b/cloudevents/tests/test_with_sanic.py
@@ -19,7 +19,7 @@ from cloudevents.sdk.event import v1
 from cloudevents.tests import data as test_data
 
 m = marshaller.NewDefaultHTTPMarshaller()
-app = Sanic()
+app = Sanic("test_with_sanic")
 
 
 @app.route("/is-ok", ["POST"])


### PR DESCRIPTION
CI is broken for some runs ([example](https://github.com/cloudevents/sdk-python/runs/5878276918?check_suite_focus=true)).

Error:

```
==================================== ERRORS ====================================
____________ ERROR collecting cloudevents/tests/test_http_events.py ____________
cloudevents/tests/test_http_events.py:69: in <module>
    app = Sanic()
.tox/py/lib/python3.6/site-packages/sanic/app.py:60: in __init__
    "Sanic instance cannot be unnamed. "
E   sanic.exceptions.SanicException: Sanic instance cannot be unnamed. Please use Sanic(name='your_application_name') instead.
____________ ERROR collecting cloudevents/tests/test_with_sanic.py _____________
cloudevents/tests/test_with_sanic.py:[22](https://github.com/cloudevents/sdk-python/runs/5878415085?check_suite_focus=true#step:5:22): in <module>
    app = Sanic()
.tox/py/lib/python3.6/site-packages/sanic/app.py:60: in __init__
    "Sanic instance cannot be unnamed. "
E   sanic.exceptions.SanicException: Sanic instance cannot be unnamed. Please use Sanic(name='your_application_name') instead.

---------- coverage: platform linux, python 3.6.15-final-0 -----------
```

Looks like the sanic instance names cannot contain a `.` char. They are currently `__name__`. It looks common to have a string literal instead.

Maybe an updated version of sanic broke this?

Run: https://github.com/cloudevents/sdk-python/runs/5878415085?check_suite_focus=true

Recent CI:

```
self = <[AttributeError('name') raised in repr()] Sanic object at 0x7fa75acd6c20>
name = 'cloudevents.tests.test_http_events', args = (), kwargs = {}
class_name = 'Sanic'

    def __init__(self, name: str = None, *args: Any, **kwargs: Any) -> None:
        class_name = self.__class__.__name__
    
        if name is None:
            raise SanicException(
                f"{class_name} instance cannot be unnamed. "
                "Please use Sanic(name='your_application_name') instead.",
            )
    
        if not VALID_NAME.match(name):
            raise SanicException(
>               f"{class_name} instance named '{name}' uses an invalid "
                "format. Names must begin with a character and may only "
                "contain alphanumeric characters, _, or -."
            )
E           sanic.exceptions.SanicException: Sanic instance named 'cloudevents.tests.test_http_events' uses an invalid format. Names must begin with a character and may only contain alphanumeric characters, _, or -.

.tox/py/lib/python3.7/site-packages/sanic/base/root.py:38: SanicException
```