### PR TITLE
ci: migrate to `main` branch

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -3,7 +3,7 @@ name: PyPI-Release
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build-and-publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Default branch changed from `master` to `main` ([#180])
+
 
 ## [1.4.0] — 2022-07-14
 ### Added
@@ -165,3 +168,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#170]: https://github.com/cloudevents/sdk-python/pull/170
 [#172]: https://github.com/cloudevents/sdk-python/pull/172
 [#173]: https://github.com/cloudevents/sdk-python/pull/173
+[#180]: https://github.com/cloudevents/sdk-python/pull/180

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,11 +7,11 @@ To release a new CloudEvents SDK, contributors should bump `__version__` in
 [cloudevents](cloudevents/__init__.py) to reflect the new release version. On merge, the action
 will automatically build and release to PyPI using
 [this PyPI GitHub Action](https://github.com/pypa/gh-action-pypi-publish). This
-action gets called on all pushes to master (such as a version branch being merged
-into master), but only releases a new version when the version number has changed. Note,
-this action assumes pushes to master are version updates. Consequently,
+action gets called on all pushes to main (such as a version branch being merged
+into main), but only releases a new version when the version number has changed. Note,
+this action assumes pushes to main are version updates. Consequently,
 [pypi-release.yml](.github/workflows/pypi-release.yml) will fail if you attempt to
-push to master without updating `__version__` in
+push to main without updating `__version__` in
 [cloudevents](cloudevents/__init__.py) so don't forget to do so.
 
 After a version update is merged, the script [pypi_packaging.py](pypi_packaging.py)

--- a/pypi_packaging.py
+++ b/pypi_packaging.py
@@ -11,6 +11,18 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
 
 import os
 
@@ -33,7 +45,7 @@ def createTag():
         repo = Repo(os.getcwd())
         repo.create_tag(pypi_config["version_target"])
 
-        # Push git tag to remote master
+        # Push git tag to remote main
         origin = repo.remote()
         origin.push(pypi_config["version_target"])
 


### PR DESCRIPTION
This PR finalizes migration from `master` to `main` in the repository. Closes #162 .