### PR TITLE
fix: `_json_or_string` no longer fails on malformed unicode buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Malformed unicode buffer encoded in `base_64` json field no-longer fail CloudEvent
  class construction ([#184])
- 
+
 ### Changed
 - Default branch changed from `master` to `main` ([#180])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Malformed unicode buffer encoded in `base_64` json field no-longer fail CloudEvent
+ class construction ([#184])
+ 
 ### Changed
 - Default branch changed from `master` to `main` ([#180])
 
@@ -169,3 +172,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#172]: https://github.com/cloudevents/sdk-python/pull/172
 [#173]: https://github.com/cloudevents/sdk-python/pull/173
 [#180]: https://github.com/cloudevents/sdk-python/pull/180
+[#184]: https://github.com/cloudevents/sdk-python/pull/184

--- a/cloudevents/http/util.py
+++ b/cloudevents/http/util.py
@@ -34,6 +34,10 @@ def _json_or_string(
         typing.AnyStr,
     ]
 ]:
+    """
+    Given an encoded JSON string MUST return decoded JSON object.
+    Otherwise, MUST return the given string as-is.
+    """
     if content is None:
         return None
     try:

--- a/cloudevents/http/util.py
+++ b/cloudevents/http/util.py
@@ -29,12 +29,12 @@ ContentT = typing.TypeVar("ContentT", bound=typing.Union[str, bytes])
 
 
 def _json_or_string(
-    content: typing.Optional[ContentT],
+    content: typing.Optional[typing.AnyStr],
 ) -> typing.Optional[
     typing.Union[
         typing.Dict[typing.Any, typing.Any],
         typing.List[typing.Any],
-        ContentT,
+        typing.AnyStr,
     ]
 ]:
     if content is None:

--- a/cloudevents/http/util.py
+++ b/cloudevents/http/util.py
@@ -25,7 +25,18 @@ def default_marshaller(content: any):
         return content
 
 
-def _json_or_string(content: typing.Optional[typing.Union[str, bytes]]):
+ContentT = typing.TypeVar("ContentT", bound=typing.Union[str, bytes])
+
+
+def _json_or_string(
+    content: typing.Optional[ContentT],
+) -> typing.Optional[
+    typing.Union[
+        typing.Dict[typing.Any, typing.Any],
+        typing.List[typing.Any],
+        ContentT,
+    ]
+]:
     if content is None:
         return None
     try:

--- a/cloudevents/http/util.py
+++ b/cloudevents/http/util.py
@@ -25,9 +25,6 @@ def default_marshaller(content: any):
         return content
 
 
-ContentT = typing.TypeVar("ContentT", bound=typing.Union[str, bytes])
-
-
 def _json_or_string(
     content: typing.Optional[typing.AnyStr],
 ) -> typing.Optional[

--- a/cloudevents/http/util.py
+++ b/cloudevents/http/util.py
@@ -30,5 +30,5 @@ def _json_or_string(content: typing.Union[str, bytes]):
         return None
     try:
         return json.loads(content)
-    except (json.JSONDecodeError, TypeError):
+    except (json.JSONDecodeError, TypeError, UnicodeDecodeError):
         return content

--- a/cloudevents/http/util.py
+++ b/cloudevents/http/util.py
@@ -25,7 +25,7 @@ def default_marshaller(content: any):
         return content
 
 
-def _json_or_string(content: typing.Union[str, bytes]):
+def _json_or_string(content: typing.Optional[typing.Union[str, bytes]]):
     if content is None:
         return None
     try:

--- a/cloudevents/tests/test_http_cloudevent.py
+++ b/cloudevents/tests/test_http_cloudevent.py
@@ -168,8 +168,19 @@ def test_cloudevent_general_overrides():
     assert len(event) == 0
 
 
-def test_none_json_or_string():
-    assert _json_or_string(None) is None
+@pytest.mark.parametrize(
+    "given, expected",
+    [
+        (None, None),
+        ('{"hello": "world"}', {"hello": "world"}),
+        (b'{"hello": "world"}', {"hello": "world"}),
+        (b"Hello World", b"Hello World"),
+        ("Hello World", "Hello World"),
+        (b"\x00\x00\x11Hello World", b"\x00\x00\x11Hello World"),
+    ],
+)
+def test_json_or_string_match_golden_sample(given, expected):
+    assert _json_or_string(given) == expected
 
 
 def test_get_operation_on_non_existing_attribute_must_not_raise_exception(


### PR DESCRIPTION
Fixes  #183
## Changes
* Add the missing exception to the list
* Add more type information

## One line description for the changelog


- [x] Tests pass
- [x] Appropriate changes to README are included in PR
