### PR TITLE
Feat/expose event attributes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: isort
         args: [ "--profile", "black", "--filter-files" ]
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.10.0
     hooks:
       - id: black
         language_version: python3.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,7 +152,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[1.6.1]: https://github.com/cloudevents/sdk-python/compare/1.6.1...1.6.2
+[1.6.2]: https://github.com/cloudevents/sdk-python/compare/1.6.1...1.6.2
 [1.6.1]: https://github.com/cloudevents/sdk-python/compare/1.6.0...1.6.1
 [1.6.0]: https://github.com/cloudevents/sdk-python/compare/1.5.0...1.6.0
 [1.5.0]: https://github.com/cloudevents/sdk-python/compare/1.4.0...1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.2] — 2022-10-18
+### Added
+- Added `get_attributes` API to the `CloudEvent` API. The method returns a read-only
+  view on the event attributes. ([#195])
+
 ## [1.6.1] — 2022-08-18
 ### Fixed
 - Missing `to_json` import. ([#191])
@@ -146,6 +151,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.1] - 2018-11-19
 ### Added
 - Initial release
+
+[1.6.1]: https://github.com/cloudevents/sdk-python/compare/1.6.1...1.6.2
 [1.6.1]: https://github.com/cloudevents/sdk-python/compare/1.6.0...1.6.1
 [1.6.0]: https://github.com/cloudevents/sdk-python/compare/1.5.0...1.6.0
 [1.5.0]: https://github.com/cloudevents/sdk-python/compare/1.4.0...1.5.0
@@ -210,3 +217,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#186]: https://github.com/cloudevents/sdk-python/pull/186
 [#188]: https://github.com/cloudevents/sdk-python/pull/188
 [#191]: https://github.com/cloudevents/sdk-python/pull/191
+[#195]: https://github.com/cloudevents/sdk-python/pull/195

--- a/cloudevents/__init__.py
+++ b/cloudevents/__init__.py
@@ -12,4 +12,4 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-__version__ = "1.6.1"
+__version__ = "1.6.2"

--- a/cloudevents/abstract/event.py
+++ b/cloudevents/abstract/event.py
@@ -14,6 +14,8 @@
 
 import typing
 from abc import abstractmethod
+from types import MappingProxyType
+from typing import Mapping
 
 
 class CloudEvent:
@@ -44,6 +46,14 @@ class CloudEvent:
         :returns: A new instance of the CloudEvent created from the passed arguments.
         """
         raise NotImplementedError()
+
+    def get_attributes(self) -> Mapping[str, typing.Any]:
+        """
+        Returns a read-only view on the attributes of the event.
+
+        :returns: Read-only view on the attributes of the event.
+        """
+        return MappingProxyType(self._get_attributes())
 
     @abstractmethod
     def _get_attributes(self) -> typing.Dict[str, typing.Any]:

--- a/cloudevents/tests/test_pydantic_events.py
+++ b/cloudevents/tests/test_pydantic_events.py
@@ -15,6 +15,7 @@
 import bz2
 import io
 import json
+import typing
 
 import pytest
 from sanic import Sanic, response
@@ -240,6 +241,25 @@ def test_structured_to_request(specversion):
     for key in attributes:
         assert body[key] == attributes[key]
     assert body["data"] == data, f"|{body_bytes}|| {body}"
+
+
+@pytest.mark.parametrize("specversion", ["1.0", "0.3"])
+def test_attributes_view_accessor(specversion: str):
+    attributes: dict[str, typing.Any] = {
+        "specversion": specversion,
+        "type": "word.found.name",
+        "id": "96fb5f0b-001e-0108-6dfe-da6e2806f124",
+        "source": "pytest",
+    }
+    data = {"message": "Hello World!"}
+
+    event: CloudEvent = CloudEvent(attributes, data)
+    event_attributes: typing.Mapping[str, typing.Any] = event.get_attributes()
+    assert event_attributes["specversion"] == attributes["specversion"]
+    assert event_attributes["type"] == attributes["type"]
+    assert event_attributes["id"] == attributes["id"]
+    assert event_attributes["source"] == attributes["source"]
+    assert event_attributes["time"]
 
 
 @pytest.mark.parametrize("specversion", ["1.0", "0.3"])


### PR DESCRIPTION
In this PR I have added a read-only `get_attributes` API to the `CloudEvent` instances. This allows for glancing at the attributes and their keys without using protected props or other hacky methods.


- [x] Tests pass
- [x] Appropriate changes to changelog are included in the PR
