### PR TITLE
ci: refine publishing WF

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,13 +1,45 @@
 name: PyPI-Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
 
 jobs:
-  build-and-publish:
-    runs-on: ubuntu-latest
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04, windows-2022, macos-12 ]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.11.2
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+  publish:
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'push'
+    needs: [ build_wheels, build_sdist ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -17,11 +49,16 @@ jobs:
           cache: 'pip'
       - name: Install build dependencies
         run: pip install -U setuptools wheel build
-      - name: Build
-        run: python -m build .
+      - uses: actions/download-artifact@v3
+        with:
+          # unpacks default artifact into dist/
+          # if `name: artifact` is omitted, the action will create extra parent dir
+          name: artifact
+          path: dist
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          user: __token__
           password: ${{ secrets.pypi_password }}
       - name: Install GitPython and cloudevents for pypi_packaging
         run: pip install -U -r requirements/publish.txt

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -2,7 +2,6 @@ name: PyPI-Release
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -8,39 +8,27 @@ on:
       - main
 
 jobs:
-  build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-22.04, windows-2022, macos-12 ]
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.2
-
-      - uses: actions/upload-artifact@v3
-        with:
-          path: ./wheelhouse/*.whl
-
-  build_sdist:
+  build_dist:
     name: Build source distribution
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-      - name: Build sdist
-        run: pipx run build --sdist
+      - name: Build SDist and wheel
+        run: pipx run build
 
       - uses: actions/upload-artifact@v3
         with:
-          path: dist/*.tar.gz
+          path: dist/*
+
+      - name: Check metadata
+        run: pipx run twine check dist/*
   publish:
     runs-on: ubuntu-22.04
     if: github.event_name == 'push'
-    needs: [ build_wheels, build_sdist ]
+    needs: [ build_dist ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -30,6 +30,8 @@ jobs:
     needs: [ build_dist ]
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -2,6 +2,7 @@ name: PyPI-Release
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added [`cibuildwheels`](https://cibuildwheel.readthedocs.io/) support 
+  for publishing ([#202])
 
 ## [1.7.0] — 2022-11-17
 ### Added
@@ -225,3 +228,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#191]: https://github.com/cloudevents/sdk-python/pull/191
 [#195]: https://github.com/cloudevents/sdk-python/pull/195
 [#197]: https://github.com/cloudevents/sdk-python/pull/197
+[#202]: https://github.com/cloudevents/sdk-python/pull/202

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
-- Added [`cibuildwheels`](https://cibuildwheel.readthedocs.io/) support
-  for publishing ([#202])
+### Changed
+- Refined build and publishing process. Added SDist to the released package ([#202])
 
 ## [1.7.0] — 2022-11-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Added [`cibuildwheels`](https://cibuildwheel.readthedocs.io/) support 
+- Added [`cibuildwheels`](https://cibuildwheel.readthedocs.io/) support
   for publishing ([#202])
 
 ## [1.7.0] — 2022-11-17


### PR DESCRIPTION
Closes #178.

## Changes

The release pipeline is refined and now builds and publishes `wheel` and `sdist`.

There is no need for `cibuildwheel` while we do not have any OS-specific libraries or extensions to build. Pure Python wheel is the best one we should deliver.