### PR TITLE
hotfix: Hotfix Pydantic dependency constraints.

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - 'tag/v**'
 
 jobs:
   build_dist:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [1.7.1] — 2022-11-21
+### Fixed
+- Fixed Pydantic extras dependency constraint (backport of v1.6.3)
+
 ### Changed
 - Refined build and publishing process. Added SDist to the released package ([#202])
 
@@ -12,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added [Kafka](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/bindings/kafka-protocol-binding.md)
   support ([#197], thanks [David Martines](https://github.com/davidwmartines))
+
+## [1.6.3] — 2022-11-21
+### Fixed
+- Fixed Pydantic extras dependency constraint.
 
 ## [1.6.2] — 2022-10-18
 ### Added
@@ -160,6 +168,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 
 [1.7.0]: https://github.com/cloudevents/sdk-python/compare/1.6.0...1.7.0
+[1.6.2]: https://github.com/cloudevents/sdk-python/compare/1.6.2...1.6.3
 [1.6.2]: https://github.com/cloudevents/sdk-python/compare/1.6.1...1.6.2
 [1.6.1]: https://github.com/cloudevents/sdk-python/compare/1.6.0...1.6.1
 [1.6.0]: https://github.com/cloudevents/sdk-python/compare/1.5.0...1.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ## [1.7.1] — 2022-11-21
 ### Fixed
-- Fixed Pydantic extras dependency constraint (backport of v1.6.3)
+- Fixed Pydantic extras dependency constraint (backport of v1.6.3, [#204])
 
 ### Changed
 - Refined build and publishing process. Added SDist to the released package ([#202])
@@ -19,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.6.3] — 2022-11-21
 ### Fixed
-- Fixed Pydantic extras dependency constraint.
+- Fixed Pydantic extras dependency constraint ([#204])
 
 ## [1.6.2] — 2022-10-18
 ### Added
@@ -167,6 +168,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[1.7.1]: https://github.com/cloudevents/sdk-python/compare/1.7.0...1.7.1
 [1.7.0]: https://github.com/cloudevents/sdk-python/compare/1.6.0...1.7.0
 [1.6.2]: https://github.com/cloudevents/sdk-python/compare/1.6.2...1.6.3
 [1.6.2]: https://github.com/cloudevents/sdk-python/compare/1.6.1...1.6.2
@@ -237,3 +239,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#195]: https://github.com/cloudevents/sdk-python/pull/195
 [#197]: https://github.com/cloudevents/sdk-python/pull/197
 [#202]: https://github.com/cloudevents/sdk-python/pull/202
+[#204]: https://github.com/cloudevents/sdk-python/pull/204

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,7 +170,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [1.7.1]: https://github.com/cloudevents/sdk-python/compare/1.7.0...1.7.1
 [1.7.0]: https://github.com/cloudevents/sdk-python/compare/1.6.0...1.7.0
-[1.6.2]: https://github.com/cloudevents/sdk-python/compare/1.6.2...1.6.3
+[1.6.3]: https://github.com/cloudevents/sdk-python/compare/1.6.2...1.6.3
 [1.6.2]: https://github.com/cloudevents/sdk-python/compare/1.6.1...1.6.2
 [1.6.1]: https://github.com/cloudevents/sdk-python/compare/1.6.0...1.6.1
 [1.6.0]: https://github.com/cloudevents/sdk-python/compare/1.5.0...1.6.0

--- a/cloudevents/__init__.py
+++ b/cloudevents/__init__.py
@@ -12,4 +12,4 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"

--- a/setup.py
+++ b/setup.py
@@ -71,8 +71,8 @@ if __name__ == "__main__":
         install_requires=["deprecation>=2.0,<3.0"],
         extras_require={
             "pydantic": [
-                "pydantic>=1.0.0<1.9.0; python_version <= '3.6'",
-                "pydantic>=1.0.0<2.0; python_version > '3.6'",
+                "pydantic>=1.0.0,<1.9.0;python_version<'3.7'",
+                "pydantic>=1.0.0,<2.0;python_version>='3.7'",
             ],
         },
     )


### PR DESCRIPTION
Fixes #203.

## Changes

The constraint had a teeny-tiny misprint (a missing `,` between the versions) that made it invalid.

This change is released separately as v1.6.3 and now as v1.7.1.