### PR TITLE
Drop python36

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] — 2022-12-08
+### Changed
+- Dropped support of Python 3.6 that has reached EOL almost a year ago.
+  [v1.7.1](https://pypi.org/project/cloudevents/1.7.1/) is the last
+  one to support Python 3.6 ([#208])
+
 ## [1.7.1] — 2022-11-21
 ### Fixed
 - Fixed Pydantic extras dependency constraint (backport of v1.6.3, [#204])
@@ -168,6 +174,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[1.8.0]: https://github.com/cloudevents/sdk-python/compare/1.7.0...1.8.0
 [1.7.1]: https://github.com/cloudevents/sdk-python/compare/1.7.0...1.7.1
 [1.7.0]: https://github.com/cloudevents/sdk-python/compare/1.6.0...1.7.0
 [1.6.3]: https://github.com/cloudevents/sdk-python/compare/1.6.2...1.6.3
@@ -240,3 +247,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#197]: https://github.com/cloudevents/sdk-python/pull/197
 [#202]: https://github.com/cloudevents/sdk-python/pull/202
 [#204]: https://github.com/cloudevents/sdk-python/pull/204
+[#208]: https://github.com/cloudevents/sdk-python/pull/208

--- a/cloudevents/__init__.py
+++ b/cloudevents/__init__.py
@@ -12,4 +12,4 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-__version__ = "1.7.1"
+__version__ = "1.8.0"

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,4 +10,4 @@ aiohttp
 Pillow
 requests
 flask
-pydantic>=1.0.0<2.0
+pydantic>=1.0.0,<2.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,12 +4,10 @@ flake8-print
 pytest
 pytest-cov
 # web app tests
-sanic<=20.12.7; python_version <= '3.6'
-sanic; python_version > '3.6'
-sanic-testing; python_version > '3.6'
+sanic
+sanic-testing
 aiohttp
 Pillow
 requests
 flask
-pydantic>=1.0.0<1.9.0; python_version <= '3.6'
-pydantic>=1.0.0<2.0; python_version > '3.6'
+pydantic>=1.0.0<2.0;

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,4 +10,4 @@ aiohttp
 Pillow
 requests
 flask
-pydantic>=1.0.0<2.0;
+pydantic>=1.0.0<2.0

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ if __name__ == "__main__":
             "Development Status :: 5 - Production/Stable",
             "Operating System :: POSIX :: Linux",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
@@ -69,10 +68,5 @@ if __name__ == "__main__":
         packages=find_packages(exclude=["cloudevents.tests"]),
         version=pypi_config["version_target"],
         install_requires=["deprecation>=2.0,<3.0"],
-        extras_require={
-            "pydantic": [
-                "pydantic>=1.0.0,<1.9.0;python_version<'3.7'",
-                "pydantic>=1.0.0,<2.0;python_version>='3.7'",
-            ],
-        },
+        extras_require={"pydantic": "pydantic>=1.0.0,<2.0"},
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,310},lint
+envlist = py{37,38,39,310},lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Fixes https://github.com/cloudevents/sdk-python/issues/177

## Changes

Python 3.6 is no longer officially supported (it should work though, just not tested against).