### PR TITLE
Pydantic v2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,4 +24,4 @@ repos:
         types: [ python ]
         args: [ ]
         additional_dependencies:
-          - "pydantic"
+          - "pydantic~=2.7"

--- a/cloudevents/pydantic/__init__.py
+++ b/cloudevents/pydantic/__init__.py
@@ -12,22 +12,31 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from typing import TYPE_CHECKING
+
 from cloudevents.exceptions import PydanticFeatureNotInstalled
 
 try:
-    from pydantic import VERSION as PYDANTIC_VERSION
-
-    pydantic_major_version = PYDANTIC_VERSION.split(".")[0]
-    if pydantic_major_version == "1":
-        from cloudevents.pydantic.v1 import CloudEvent, from_dict, from_http, from_json
-
+    if TYPE_CHECKING:
+        from cloudevents.pydantic.v2 import CloudEvent, from_dict, from_http, from_json
     else:
-        from cloudevents.pydantic.v2 import (  # type: ignore
-            CloudEvent,
-            from_dict,
-            from_http,
-            from_json,
-        )
+        from pydantic import VERSION as PYDANTIC_VERSION
+
+        pydantic_major_version = PYDANTIC_VERSION.split(".")[0]
+        if pydantic_major_version == "1":
+            from cloudevents.pydantic.v1 import (
+                CloudEvent,
+                from_dict,
+                from_http,
+                from_json,
+            )
+        else:
+            from cloudevents.pydantic.v2 import (
+                CloudEvent,
+                from_dict,
+                from_http,
+                from_json,
+            )
 
 except ImportError:  # pragma: no cover # hard to test
     raise PydanticFeatureNotInstalled(

--- a/cloudevents/pydantic/v2/event.py
+++ b/cloudevents/pydantic/v2/event.py
@@ -51,53 +51,53 @@ class CloudEvent(abstract.CloudEvent, BaseModel):  # type: ignore
     data: typing.Optional[typing.Any] = Field(
         title=FIELD_DESCRIPTIONS["data"].get("title"),
         description=FIELD_DESCRIPTIONS["data"].get("description"),
-        example=FIELD_DESCRIPTIONS["data"].get("example"),
+        examples=[FIELD_DESCRIPTIONS["data"].get("example")],
         default=None,
     )
     source: str = Field(
         title=FIELD_DESCRIPTIONS["source"].get("title"),
         description=FIELD_DESCRIPTIONS["source"].get("description"),
-        example=FIELD_DESCRIPTIONS["source"].get("example"),
+        examples=[FIELD_DESCRIPTIONS["source"].get("example")],
     )
     id: str = Field(
         title=FIELD_DESCRIPTIONS["id"].get("title"),
         description=FIELD_DESCRIPTIONS["id"].get("description"),
-        example=FIELD_DESCRIPTIONS["id"].get("example"),
+        examples=[FIELD_DESCRIPTIONS["id"].get("example")],
         default_factory=attribute.default_id_selection_algorithm,
     )
     type: str = Field(
         title=FIELD_DESCRIPTIONS["type"].get("title"),
         description=FIELD_DESCRIPTIONS["type"].get("description"),
-        example=FIELD_DESCRIPTIONS["type"].get("example"),
+        examples=[FIELD_DESCRIPTIONS["type"].get("example")],
     )
     specversion: attribute.SpecVersion = Field(
         title=FIELD_DESCRIPTIONS["specversion"].get("title"),
         description=FIELD_DESCRIPTIONS["specversion"].get("description"),
-        example=FIELD_DESCRIPTIONS["specversion"].get("example"),
+        examples=[FIELD_DESCRIPTIONS["specversion"].get("example")],
         default=attribute.DEFAULT_SPECVERSION,
     )
     time: typing.Optional[datetime.datetime] = Field(
         title=FIELD_DESCRIPTIONS["time"].get("title"),
         description=FIELD_DESCRIPTIONS["time"].get("description"),
-        example=FIELD_DESCRIPTIONS["time"].get("example"),
+        examples=[FIELD_DESCRIPTIONS["time"].get("example")],
         default_factory=attribute.default_time_selection_algorithm,
     )
     subject: typing.Optional[str] = Field(
         title=FIELD_DESCRIPTIONS["subject"].get("title"),
         description=FIELD_DESCRIPTIONS["subject"].get("description"),
-        example=FIELD_DESCRIPTIONS["subject"].get("example"),
+        examples=[FIELD_DESCRIPTIONS["subject"].get("example")],
         default=None,
     )
     datacontenttype: typing.Optional[str] = Field(
         title=FIELD_DESCRIPTIONS["datacontenttype"].get("title"),
         description=FIELD_DESCRIPTIONS["datacontenttype"].get("description"),
-        example=FIELD_DESCRIPTIONS["datacontenttype"].get("example"),
+        examples=[FIELD_DESCRIPTIONS["datacontenttype"].get("example")],
         default=None,
     )
     dataschema: typing.Optional[str] = Field(
         title=FIELD_DESCRIPTIONS["dataschema"].get("title"),
         description=FIELD_DESCRIPTIONS["dataschema"].get("description"),
-        example=FIELD_DESCRIPTIONS["dataschema"].get("example"),
+        examples=[FIELD_DESCRIPTIONS["dataschema"].get("example")],
         default=None,
     )
 


### PR DESCRIPTION
## Changes

The `pydantic.VERSION` variable is not a Literal expression, so mypy is unable to assert whether we're in an environment running on Pydantic V2 or V1. This results in mypy trying to follow both paths and failing with a `no-redef` error, which is silenced by the `# type: ignore` comment.

This PR improves the code quality by removing the `# type: ignore` comment and adding a `if TYPE_CHECKING` block that only imports the latest version (V2).

This was the main intent of the PR. As a bonus, this also updates the `example` kwarg to `examples`, as it is expected for Pydantic V2.

## One line description for the changelog

Improved Pydantic V2 typechecking support.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR _(Pydantic is not referenced in the README)_
