### PR TITLE
fix: remove few mentions of py38

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -80,7 +79,7 @@ packages = ["src/cloudevents"]
 
 [tool.ruff]
 line-length = 88
-target-version = "py38"
+target-version = "py39"
 
 exclude = [
     ".bzr",


### PR DESCRIPTION
## Changes
 - PY38 is EOL, so let's not mention it here

## One line description for the changelog


- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
