### PR TITLE
fix: improve json handling on wrong or missing contenttype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated dev and build-time dependencies.
 
+### Fixed
+
+- Fixed an issue where setting a non-JSON datacontenttype (e.g., application/octet-stream) with dict data produced non-JSON-decodable output; now best-effort json-encoding is applied regardless of datacontenttype. ([#291])
+- Updated behavior when datacontenttype is unset: now treats events as application/json in line with spec recommendation. ([#291])
+
 ## [2.1.0]
 
 ### Added

--- a/src/cloudevents/core/formats/json.py
+++ b/src/cloudevents/core/formats/json.py
@@ -44,6 +44,7 @@ class _JSONEncoderWithDatetime(JSONEncoder):
 
 class JSONFormat(Format):
     CONTENT_TYPE: Final[str] = "application/cloudevents+json"
+    DEFAULT_CONTENT_TYPE: Final[str] = "application/json"
     JSON_CONTENT_TYPE_PATTERN: Pattern[str] = re.compile(
         r"^(application|text)/([a-zA-Z0-9\-\.]+\+)?json(;.*)?$"
     )
@@ -135,7 +136,9 @@ class JSONFormat(Format):
                         "utf-8"
                     )
             else:
-                datacontenttype = event_dict.get("datacontenttype", "application/json")
+                datacontenttype = event_dict.get(
+                    "datacontenttype", self.DEFAULT_CONTENT_TYPE
+                )
                 if re.match(JSONFormat.JSON_CONTENT_TYPE_PATTERN, datacontenttype):
                     event_dict["data"] = event_data
                 else:
@@ -171,12 +174,19 @@ class JSONFormat(Format):
 
         # If data is a dict and content type is JSON, serialize as JSON
         if isinstance(data, dict):
-            if datacontenttype and re.match(
-                JSONFormat.JSON_CONTENT_TYPE_PATTERN, datacontenttype
-            ):
+            content_type = datacontenttype or self.DEFAULT_CONTENT_TYPE
+            if re.match(JSONFormat.JSON_CONTENT_TYPE_PATTERN, content_type):
                 return dumps(data, cls=_JSONEncoderWithDatetime).encode("utf-8")
 
-        # Default: convert to string and encode
+            # for other contenttypes we still try to generate a json-decodable string
+            # if not possible, a string representing
+            try:
+                return dumps(data, cls=_JSONEncoderWithDatetime).encode("utf-8")
+            except TypeError:
+                pass
+
+        # according to the spec, we return an encoded string per default
+        # careful: the result is not json-decodable as the dict keys are single-quoted
         return str(data).encode("utf-8")
 
     def read_data(
@@ -196,9 +206,8 @@ class JSONFormat(Format):
             return None
 
         # If content type indicates JSON, try to parse as JSON
-        if datacontenttype and re.match(
-            JSONFormat.JSON_CONTENT_TYPE_PATTERN, datacontenttype
-        ):
+        content_type = datacontenttype or self.DEFAULT_CONTENT_TYPE
+        if re.match(JSONFormat.JSON_CONTENT_TYPE_PATTERN, content_type):
             try:
                 decoded = body.decode("utf-8")
                 parsed: dict[str, Any] = loads(decoded)

--- a/tests/test_core/test_format/test_json.py
+++ b/tests/test_core/test_format/test_json.py
@@ -12,8 +12,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-
 from datetime import datetime, timezone
+from json import loads
+
+import pytest
 
 from cloudevents.core.formats.json import JSONFormat
 from cloudevents.core.v1.event import CloudEvent
@@ -323,3 +325,24 @@ def test_read_cloud_event_from_string_input() -> None:
 
     assert result.get_id() == "123"
     assert result.get_source() == "source"
+
+
+@pytest.mark.parametrize(
+    "content_type", [None, "application/json", "application/octet-stream"]
+)
+def test_write_data_dict(content_type: str) -> None:
+    formatter = JSONFormat()
+    data = {"key": "value", "nested": {"a": 1}}
+    result = formatter.write_data(data, datacontenttype=content_type)
+
+    assert isinstance(result, bytes)
+    assert loads(result) == data
+
+
+@pytest.mark.parametrize("content_type", [None, "application/json"])
+def test_read_data_json_body(content_type: str) -> None:
+    formatter = JSONFormat()
+    body = b'{"key": "value"}'
+    result = formatter.read_data(body, content_type)
+
+    assert result == {"key": "value"}


### PR DESCRIPTION
<!--
Thank you for contributing to the project!

Please make sure to read the `CONTRIBUTING.md` file for our contribution guidelines:
https://github.com/cloudevents/sdk-python/blob/main/CONTRIBUTING.md
-->

<!--
Please provide a clear and concise description of the pull request.
-->

**Related Issue:** #291

**Type of change:**
<!--
Please select one of the following options and delete the others.
-->
- Bug fix (non-breaking change which fixes an issue)

**Description:**
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

- When users set datacontenttype to something like `application/octet-stream` but pass a dict as data, the JSONFormatter now produces JSON-decodable output.
- The spec states that when datacontenttype is unspecified, processing SHOULD proceed as if it were application/json.

---

**Pre-submission checklist:**
- [x] I have read the [CONTRIBUTING.md](https://github.com/cloudevents/sdk-python/blob/main/CONTRIBUTING.md) file.
- [x] I have signed off my commits using `git commit --signoff`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation (`README.md`, `CHANGELOG.md`, etc.) as necessary.
- [x] I have run `pre-commit` and `tox` and all checks pass.
- [x] This pull request is ready to be reviewed.
