### PR TITLE
fix: name the missing required headers on binary HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `from_http` now names the required binary headers that are actually missing,
+  instead of always reporting a missing `specversion`. ([#139])
+
 ## [2.2.0]
 
 ### Changed
@@ -368,3 +373,4 @@ CloudEvents v2 is a rewrite with ongoing development ([#271])
 [#279]: https://github.com/cloudevents/sdk-python/pull/279
 [#284]: https://github.com/cloudevents/sdk-python/pull/284
 [#291]: https://github.com/cloudevents/sdk-python/pull/291
+[#139]: https://github.com/cloudevents/sdk-python/issues/139

--- a/src/cloudevents/v1/conversion.py
+++ b/src/cloudevents/v1/conversion.py
@@ -22,6 +22,27 @@ from cloudevents.v1.sdk import converters, marshaller, types
 from cloudevents.v1.sdk.converters import is_binary
 from cloudevents.v1.sdk.event import v03, v1
 
+_REQUIRED_BINARY_HEADERS = ("ce-specversion", "ce-id", "ce-source", "ce-type")
+
+
+def _missing_binary_headers(
+    headers: typing.Mapping[str, str],
+) -> typing.List[str]:
+    """
+    Lists the required binary-mode headers missing from a partially populated
+    binary HTTP request.
+
+    Returns an empty list when no binary header is present at all, since such a
+    request is not an incomplete binary one.
+
+    :param headers: The lower-cased HTTP request headers.
+    :returns: The missing required binary headers.
+    """
+    missing = [header for header in _REQUIRED_BINARY_HEADERS if header not in headers]
+    if len(missing) == len(_REQUIRED_BINARY_HEADERS):
+        return []
+    return missing
+
 
 def _best_effort_serialize_to_json(  # type: ignore[no-untyped-def]
     value: typing.Any, *args, **kwargs
@@ -146,6 +167,12 @@ def from_http(
             )
 
     if specversion is None:
+        missing_binary_headers = _missing_binary_headers(headers)
+        if missing_binary_headers:
+            raise cloud_exceptions.MissingRequiredFields(
+                "Failed to find the following required headers in the binary "
+                "HTTP request: {}".format(", ".join(missing_binary_headers))
+            )
         raise cloud_exceptions.MissingRequiredFields(
             "Failed to find specversion in HTTP request"
         )

--- a/tests/test_v1_compat/test_http_events.py
+++ b/tests/test_v1_compat/test_http_events.py
@@ -103,6 +103,19 @@ def test_missing_required_fields_empty_data_binary(headers):
         _ = from_http(headers, None)
 
 
+@pytest.mark.parametrize(
+    "headers, missing_header",
+    list(
+        zip(invalid_test_headers, ["ce-id", "ce-source", "ce-type", "ce-specversion"])
+    ),
+)
+def test_missing_required_fields_binary_names_missing_header(headers, missing_header):
+    # Test for issue #139
+    with pytest.raises(cloud_exceptions.MissingRequiredFields) as e:
+        _ = from_http(headers, json.dumps(test_data))
+    assert missing_header in str(e.value)
+
+
 @pytest.mark.parametrize("specversion", ["1.0", "0.3"])
 def test_emit_binary_event(specversion):
     headers = {


### PR DESCRIPTION
Closes #139

**Related Issue:** #139

**Type of change:**
- Bug fix (non-breaking change which fixes an issue)

**Description:**

A binary-mode request missing `ce-id`, `ce-source` or `ce-type` fails the binary converter's `can_read` check, so `from_http` falls through to the structured branch and reports `Failed to find specversion in HTTP request` even though `ce-specversion` is present — pointing at the wrong header.

`from_http` now names the required binary headers that are actually absent, but only when at least one of them is present; a request with no `ce-` headers at all is genuinely structured and keeps the existing message.

---

**Pre-submission checklist:**
- [x] I have read the [CONTRIBUTING.md](https://github.com/cloudevents/sdk-python/blob/main/CONTRIBUTING.md) file.
- [x] I have signed off my commits using `git commit --signoff`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation (`README.md`, `CHANGELOG.md`, etc.) as necessary.
- [ ] I have run `pre-commit` and `tox` and all checks pass.
- [x] This pull request is ready to be reviewed.

`ruff check`/`ruff format` are clean on the changed files and the new test fails without the fix and passes with it; `tox`'s full matrix was not run locally (single interpreter available).

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
